### PR TITLE
help.py - remove duplicated cmds

### DIFF
--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -60,6 +60,7 @@ def help(bot, trigger):
             name_length = max(6, max(len(k) for k in bot.command_groups.keys()))
             for category, cmds in collections.OrderedDict(sorted(bot.command_groups.items())).items():
                 category = category.upper().ljust(name_length)
+                cmds = set(cmds)  # remove duplicates
                 cmds = '  '.join(cmds)
                 msg = category + '  ' + cmds
                 indent = ' ' * (name_length + 2)


### PR DESCRIPTION
remove duplicated cmds (those are showing after reloading modules)